### PR TITLE
implement candidate_hosts for slurm adaptor

### DIFF
--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -71,7 +71,7 @@ _ADAPTOR_CAPABILITIES  = {
                           saga.job.TOTAL_PHYSICAL_MEMORY, 
                           #saga.job.CPU_ARCHITECTURE, 
                           #saga.job.OPERATING_SYSTEM_TYPE, 
-                          #saga.job.CANDIDATE_HOSTS,
+                          saga.job.CANDIDATE_HOSTS,
                           saga.job.QUEUE,
                           saga.job.PROJECT,
                           saga.job.JOB_CONTACT],
@@ -426,7 +426,8 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
         project = None
         job_memory = None
         job_contact = None
-        
+        candidate_hosts = None
+
         # check to see what's available in our job description
         # to override defaults
 
@@ -472,6 +473,12 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
 
         if jd.attribute_exists("total_physical_memory"):
             job_memory = jd.total_physical_memory
+
+        if jd.attribute_exists("candidate_hosts"):
+            if isinstance(jd.candidate_hosts, list):
+                candidate_hosts = ','.join(jd.candidate_hosts)
+            else:
+                candidate_hosts = jd.candidate_hosts
 
         if jd.attribute_exists("job_contact"):
             job_contact = jd.job_contact[0]
@@ -534,6 +541,9 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
 
         if  job_memory:
             slurm_script += "#SBATCH --mem=%s\n" % job_memory
+
+        if  candidate_hosts:
+            slurm_script += "#SBATCH --nodelist=%s\n" % candidate_hosts
 
         if  job_contact:
             slurm_script += "#SBATCH --mail-user=%s\n" % job_contact


### PR DESCRIPTION
list of host names which are to be considered
by the resource manager as candidate targets

taking advantage of the --nodelist sbatch option from SLURM:

--nodelist=<node name list>
Request a specific list of node names. The list may be specified as
a comma-separated list of node names, or a range of node names (e.g.
mynode[1-5,7,...]). Duplicate node names in the list will be ignored.
The order of the node names in the list is not important; the node names
will be sorted by SLURM.