### PR TITLE
Add PROCESSES_PER_HOST to all job adaptors.

### DIFF
--- a/src/saga/adaptors/condor/condorjob.py
+++ b/src/saga/adaptors/condor/condorjob.py
@@ -230,6 +230,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WORKING_DIRECTORY,
                           saga.job.CANDIDATE_HOSTS,
                           saga.job.TOTAL_CPU_COUNT,
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.SPMD_VARIATION, # TODO: 'hot'-fix for BigJob
                           saga.job.FILE_TRANSFER],
     "job_attributes":    [saga.job.EXIT_CODE,

--- a/src/saga/adaptors/loadl/loadljob.py
+++ b/src/saga/adaptors/loadl/loadljob.py
@@ -130,6 +130,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WALL_TIME_LIMIT,
                           saga.job.WORKING_DIRECTORY,
                           saga.job.TOTAL_PHYSICAL_MEMORY,
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.TOTAL_CPU_COUNT],
     "job_attributes":    [saga.job.EXIT_CODE,
                           saga.job.EXECUTION_HOSTS,

--- a/src/saga/adaptors/lsf/lsfjob.py
+++ b/src/saga/adaptors/lsf/lsfjob.py
@@ -247,6 +247,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WALL_TIME_LIMIT,
                           saga.job.WORKING_DIRECTORY,
                           saga.job.SPMD_VARIATION, # TODO: 'hot'-fix for BigJob
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.TOTAL_CPU_COUNT],
     "job_attributes":    [saga.job.EXIT_CODE,
                           saga.job.EXECUTION_HOSTS,

--- a/src/saga/adaptors/pbs/pbsjob.py
+++ b/src/saga/adaptors/pbs/pbsjob.py
@@ -356,6 +356,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WORKING_DIRECTORY,
                           saga.job.WALL_TIME_LIMIT,
                           saga.job.SPMD_VARIATION, # TODO: 'hot'-fix for BigJob
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.TOTAL_CPU_COUNT],
     "job_attributes":    [saga.job.EXIT_CODE,
                           saga.job.EXECUTION_HOSTS,

--- a/src/saga/adaptors/pbspro/pbsprojob.py
+++ b/src/saga/adaptors/pbspro/pbsprojob.py
@@ -355,6 +355,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WORKING_DIRECTORY,
                           saga.job.WALL_TIME_LIMIT,
                           saga.job.SPMD_VARIATION, # TODO: 'hot'-fix for BigJob
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.TOTAL_CPU_COUNT],
     "job_attributes":    [saga.job.EXIT_CODE,
                           saga.job.EXECUTION_HOSTS,

--- a/src/saga/adaptors/sge/sgejob.py
+++ b/src/saga/adaptors/sge/sgejob.py
@@ -153,6 +153,7 @@ _ADAPTOR_CAPABILITIES = {
                           saga.job.WORKING_DIRECTORY,
                           saga.job.SPMD_VARIATION,
                           saga.job.TOTAL_CPU_COUNT,
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.TOTAL_PHYSICAL_MEMORY],
     "job_attributes":    [saga.job.EXIT_CODE,
                           saga.job.EXECUTION_HOSTS,

--- a/src/saga/adaptors/shell/shell_job.py
+++ b/src/saga/adaptors/shell/shell_job.py
@@ -191,6 +191,7 @@ _ADAPTOR_CAPABILITIES  = {
                           saga.job.ERROR,
                           saga.job.WALL_TIME_LIMIT, # TODO: 'hot'-fix for BigJob - implement properly
                           saga.job.TOTAL_CPU_COUNT, # TODO: 'hot'-fix for BigJob - implement properly
+                          saga.job.PROCESSES_PER_HOST,
                           saga.job.SPMD_VARIATION,  # TODO: 'hot'-fix for BigJob - implement properly
                          ],
     "job_attributes"   : [saga.job.EXIT_CODE,


### PR DESCRIPTION
Even if they don't use it directly, they should not stumble over it, which
currently breaks RP with many adaptors.

Maybe this needs to be extended with a warning or so if the adaptor has no
native support for this?

Andre, any reason not to merge this now and possibly create tickets to solve it properly?