### PR TITLE
Add contexts to session at start of context list

### DIFF
--- a/src/saga/session.py
+++ b/src/saga/session.py
@@ -77,7 +77,9 @@ class _ContextList (list) :
                 raise se.BadParameter (msg)
 
         # context initialized ok, add it to the list of known contexts
-        super (_ContextList, self).append (ctx_clone)
+        # place added context at start of context list to ensure it is tried
+        # first when attempting a connection
+        super (_ContextList, self).insert (0, ctx_clone)
 
 
 


### PR DESCRIPTION
When a session is created without the default=False property, it sets up contexts for all the SSH keys in a user's ~/.ssh directory. If many keys are present in that directory, this results in a number of registered security contexts. When attempting an SSH connection, these contexts are tried in order to see if a connection can be made. If many invalid keys are tried, the remote side may reject the login attempt due to too many incorrect authentication attempts being made.

When adding an explicit context using session.add_context(ctx), this is added to the end of the context list meaning that all other security contexts are tried first when attempting authentication and authentication will fail before reaching the explicitly added, valid context.

By adding contexts to the beginning of the context list, authentication attempts use the most recently added context first, allowing authentication to proceed successfully if the most recently added context is valid.