### PR TITLE
Add contexts to session at start of context list

### DIFF
--- a/src/saga/session.py
+++ b/src/saga/session.py
@@ -48,8 +48,24 @@ class _ContextList (list) :
     #
     def append (self, ctx, session=None) :
 
+        ctx_clone = self._initialise_context(ctx, session)
+
+        # context initialized ok, add it to the list of known contexts
+        super (_ContextList, self).append (ctx_clone)
+        
+    def insert(self, index, ctx, session=None) :
+
+        ctx_clone = self._initialise_context(ctx, session)
+
+        # context initialized ok, add it to the list of known contexts
+        super (_ContextList, self).insert (0, ctx_clone)
+    
+    # Initialise a context to be added to the list of known contexts
+    # Returns a cloned, initialised context that can be added to the context
+    # list. 
+    def _initialise_context(self, ctx, session=None):
         if  not isinstance (ctx, saga.Context) :
-            raise TypeError, "appended item is not a saga.Context instance"
+            raise TypeError, "item to add is not a saga.Context instance"
 
         # create a deep copy of the context (this keeps _adaptor etc)
         ctx_clone = saga.Context  (ctx.type)
@@ -76,12 +92,7 @@ class _ContextList (list) :
                 msg = "Cannot add context, initialization failed (%s)"  %  str(e)
                 raise se.BadParameter (msg)
 
-        # context initialized ok, add it to the list of known contexts
-        # place added context at start of context list to ensure it is tried
-        # first when attempting a connection
-        super (_ContextList, self).insert (0, ctx_clone)
-
-
+        return ctx_clone
 
 # ------------------------------------------------------------------------------
 #
@@ -262,7 +273,7 @@ class Session (saga.base.SimpleBase) :
         It is encouraged to use the L{contexts} property instead. 
         """
 
-        return self.contexts.append (ctx=ctx, session=self)
+        return self.contexts.insert (0, ctx=ctx, session=self)
 
 
     # ----------------------------------------------------------------

--- a/src/saga/session.py
+++ b/src/saga/session.py
@@ -77,7 +77,9 @@ class _ContextList (list) :
                 raise se.BadParameter (msg)
 
         # context initialized ok, add it to the list of known contexts
-        super (_ContextList, self).append (ctx_clone)
+        # place added context at start of context list to ensure it is tried
+        # first when attempting a connection
+        super (_ContextList, self).insert (0, ctx_clone)
 
 
 


### PR DESCRIPTION
Recreation of PR #445 targetting devel branch rather than master:

When a session is created without the default=False property, it sets up contexts for all the SSH keys in a user's ~/.ssh directory. If many keys are present in that directory, this results in a number of registered security contexts. When attempting an SSH connection, these contexts are tried in order to see if a connection can be made. If many invalid keys are tried, the remote side may reject the login attempt due to too many incorrect authentication attempts being made.

When adding an explicit context using session.add_context(ctx), this is added to the end of the context list meaning that all other security contexts are tried first when attempting authentication and authentication will fail before reaching the explicitly added, valid context.

By adding contexts to the beginning of the context list, authentication attempts use the most recently added context first, allowing authentication to proceed successfully if the most recently added context is valid.