### PR TITLE
significant space...

### DIFF
--- a/src/saga/utils/pty_shell.py
+++ b/src/saga/utils/pty_shell.py
@@ -777,7 +777,7 @@ class PTYShell (object) :
 
             try :
                 command = command.strip ()
-                self.send (" %s\n" % command)
+                self.send ("%s\n" % command)
 
             except Exception as e :
                 raise ptye.translate_exception (e)


### PR DESCRIPTION
Don't we all love small commits which have a gazillion possible consequences?  Well, this is one of them.  The space removal will make some of our commands show up in the bash history again, but also will remove an error when the shell wrapper parses multi line requests which have been send asynchronously, like when doing bulk job submission...