### PR TITLE
reinterpret slurm's `COMPLETING` / `CG` state

### DIFF
--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -664,7 +664,7 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
         elif slurmjs == "CONFIGURING" or slurmjs == 'CF':
             return saga.job.PENDING
         elif slurmjs == "COMPLETING" or slurmjs == 'CG':
-            return saga.job.RUNNING
+            return saga.job.CANCELED
         elif slurmjs == "FAILED" or slurmjs == 'F':
             return saga.job.FAILED
         elif slurmjs == "NODE_FAIL" or slurmjs == 'NF':


### PR DESCRIPTION
The job got the cancellation command, it just takes some time to clean the nodes it seems (slow FS?).  So, accept this, and move on.