### PR TITLE
Recent NCSA suggestion introduced regression.

### DIFF
--- a/src/saga/adaptors/torque/torquejob.py
+++ b/src/saga/adaptors/torque/torquejob.py
@@ -288,8 +288,8 @@ def _torquescript_generator(url, logger, jd, ppn, gres, torque_version, is_cray=
             logger.info("Using Edison@NERSC (Cray XC30) specific '#PBS -l mppwidth=xx' parameter.")
             pbs_params += "#PBS -l mppwidth=%s \n" % jd.total_cpu_count
         elif 'bw.ncsa.illinois.edu' in url.host:
-            logger.info("Using Blue Waters (Cray XE6/XK7) specific '#PBS -l nodes=xx'")
-            pbs_params += "#PBS -l nodes=%d\n" % nnodes
+            logger.info("Using Blue Waters (Cray XE6/XK7) specific '#PBS -l nodes=xx:ppn=yy'")
+            pbs_params += "#PBS -l nodes=%d:ppn=%d\n" % (nnodes, ppn)
         elif 'Version: 5.' in torque_version:
             # What would removing this catchall break?
             logger.info("Using TORQUE 5.x notation '#PBS -l procs=XX' ")


### PR DESCRIPTION
NCSA recently suggested us to move from cores to nodes. As BW uses a default ppn of 1, this lead to a RP slot count of 1 per node.