### PR TITLE
Feature/empty attrib init

### DIFF
--- a/src/saga/attributes.py
+++ b/src/saga/attributes.py
@@ -330,14 +330,17 @@ class Attributes (_AttributesBase, ru.DictMixin) :
         # we use similar mechanism to initialize attribs here:
 
         for arg in args :
-            if  isinstance (arg, dict) :
+            if arg == None:
+                # be resiliant to empty initialization
+                pass
+            elif isinstance (arg, dict):
                 d['extensible']  = True   # it is just being extended ;)
                 d['camelcasing'] = True   # default for dict inits
-                for key in arg.keys () :
-                    us_key = self._attributes_t_underscore (key)
-                    self._attributes_i_set (us_key, arg[key], force=True, flow=self._UP)
-            else :
-                raise se.BadParameter ("initialization expects dictionary")
+                for key in arg.keys():
+                    us_key = self._attributes_t_underscore(key)
+                    self._attributes_i_set(us_key, arg[key], force=True, flow=self._UP)
+            else:
+                raise se.BadParameter("initialization expects dictionary")
 
         for key in kwargs.keys () :
             self.set_attribute (key, kwargs[key])

--- a/src/saga/attributes.py
+++ b/src/saga/attributes.py
@@ -2668,6 +2668,18 @@ class Attributes (_AttributesBase, ru.DictMixin) :
 
     # --------------------------------------------------------------------------
     #
+    @rus.takes   ('Attributes',
+                  dict)
+    @rus.returns (dict)
+    def from_dict (self, seed):
+        """ set attributes from dict """
+
+        for k,v in seed.iteritems():
+            self.set_attribute(k,v)
+
+
+    # --------------------------------------------------------------------------
+    #
     @rus.takes   ('Attributes')
     @rus.returns (dict)
     def as_dict (self) :


### PR DESCRIPTION
add a `from_dict()` to the attrib interface (symmetric to the existing `to_dict()`).  This can be used to initialize attribute-inheriting objects via a dict.  Specifically, this is used in an RP branch to have pilot and units descriptions initialized by a dict.