### PR TITLE
Fix #477, set session for shell job service

### DIFF
--- a/src/saga/adaptors/shell/shell_job.py
+++ b/src/saga/adaptors/shell/shell_job.py
@@ -455,6 +455,10 @@ class ShellJobService (saga.adaptors.cpi.job.Service) :
         self.jobs    = dict()
         self.njobs   = 0
 
+        # Use `_set_session` method of the base class to set the session object.
+        # `_set_session` and `get_session` methods are provided by `CPIBase`.
+        self._set_session(session)
+
         # if the rm URL specifies a path, we interprete that as shell to run.
         # Otherwise, we default to running /bin/sh (for fork) or the user's
         # login shell (for ssh etc).
@@ -462,9 +466,9 @@ class ShellJobService (saga.adaptors.cpi.job.Service) :
             self.opts['shell'] = self.rm.path
 
         # create and initialize connection for starting jobs
-        self.shell   = saga.utils.pty_shell.PTYShell (self.rm, self.session, 
+        self.shell   = saga.utils.pty_shell.PTYShell (self.rm, self.get_session(), 
                                                       self._logger, opts=self.opts)
-        self.channel = saga.utils.pty_shell.PTYShell (self.rm, self.session, 
+        self.channel = saga.utils.pty_shell.PTYShell (self.rm, self.get_session(), 
                                                       self._logger, opts=self.opts)
         self.initialize ()
 

--- a/tests/unittests/api/job/test_job.py
+++ b/tests/unittests/api/job/test_job.py
@@ -110,6 +110,29 @@ def test_job_service_create():
 
 # ------------------------------------------------------------------------------
 #
+def test_job_service_get_session():
+    """ Test if the job service session is set correctly
+    """
+    js = None
+    session = None
+    try:
+        tc = testing.get_test_config ()
+        session = tc.session or saga.Session()
+        js = saga.job.Service(tc.job_service_url, session)
+
+        assert js.get_session() == session, "Setting service session failed."
+        assert js.session == session, "Setting service session failed."
+        assert js._adaptor.get_session() == session, "Setting service session failed."
+        assert js._adaptor.session == session, "Setting service session failed."
+
+    except saga.SagaException as ex:
+        assert False, "unexpected exception %s" % ex
+    finally:
+        _silent_close_js(js)
+
+
+# ------------------------------------------------------------------------------
+#
 def test_job_run():
     """ Test job.run() - expecting state: RUNNING/PENDING
     """


### PR DESCRIPTION
This commit sets the session for `ShellJobService`. As far as I looked at the code, there are two methods called `_set_session` and `get_session` in `saga.adaptors.cpi.base.CPIBase` class which I think should be used in `init_instance` methods of `Service` classes to set the session on the service object correctly. However, this is not called in different job implementations such as pbs, sge and probably others. Shall we add this to all the other ones as well?