### PR TITLE
Devel

### DIFF
--- a/src/saga/adaptors/shell/shell_file.py
+++ b/src/saga/adaptors/shell/shell_file.py
@@ -266,8 +266,12 @@ class ShellDirectory (saga.adaptors.cpi.filesystem.Directory) :
         self.valid       = False # will be set by initialize
         self.lm          = session._lease_manager
 
+        # Use `_set_session` method of the base class to set the session object.
+        # `_set_session` and `get_session` methods are provided by `CPIBase`.
+        self._set_session(session)
+
         def _shell_creator (url) :
-            return sups.PTYShell (url, self.session, self._logger)
+            return sups.PTYShell (url, self.get_session(), self._logger)
         self.shell_creator = _shell_creator
 
         # The dir command shell is leased, as the dir seems to be used
@@ -989,9 +993,12 @@ class ShellFile (saga.adaptors.cpi.filesystem.File) :
             if  not self.flags :
                 self.flags = 0
 
+        # Use `_set_session` method of the base class to set the session object
+        # `_set_session` and `get_session` methods are provided by `CPIBase`.
+        self._set_session(session)
 
         def _shell_creator (url) :
-            return sups.PTYShell (url, self.session, self._logger)
+            return sups.PTYShell (url, self.get_session(), self._logger)
         self.shell_creator = _shell_creator
 
         # self.shell is also a leased shell -- for File, it does not have any

--- a/tests/unittests/api/filesystem/test_file.py
+++ b/tests/unittests/api/filesystem/test_file.py
@@ -170,4 +170,39 @@ class TestFile(unittest.TestCase):
         except saga.SagaException as ex:
             assert False, "Unexpected exception: %s" % ex
 
+    # -------------------------------------------------------------------------
+    #
+    def test_file_get_session(self):
+        """ Testing if the correct session is being used
+        """
+        try:
+            tc = testing.get_test_config ()
+            session = tc.session or saga.Session()
+            filename = deepcopy(saga.Url(tc.filesystem_url))
+            filename.path += "/%s" % self.uniquefilename1
 
+            f = saga.filesystem.File(filename, saga.filesystem.CREATE,
+                                     session=session)
+            assert f.get_session() == session, 'Failed setting the session'
+
+            f2 = saga.filesystem.File(f.url, session=session)
+            assert f2.get_session() == session, 'Failed setting the session'
+
+        except saga.SagaException as ex:
+            assert False, "Unexpected exception: %s" % ex
+
+    # -------------------------------------------------------------------------
+    #
+    def test_directory_get_session(self):
+        """ Testing if the correct session is being used
+        """
+        try:
+            tc = testing.get_test_config()
+            session = tc.session or saga.Session()
+
+            d = saga.filesystem.Directory(tc.filesystem_url, session=session)
+
+            assert d.get_session() == session, 'Failed setting the session'
+
+        except saga.SagaException as ex:
+            assert False, "Unexpected exception: %s" % ex


### PR DESCRIPTION
This PR addresses incorrect sessions on `saga.filesystem.File` and `saga.filesystem.Directory` instances and is part of #480 . Without this fix, saga File and Directory instances will use the default session to carry on file operations, regardless of user provided session and security contexts (such as userpass).