### PR TITLE
Fix for #500. Modified job state monitor to correctly identify state changes.

### DIFF
--- a/src/saga/adaptors/pbs/pbsjob.py
+++ b/src/saga/adaptors/pbs/pbsjob.py
@@ -69,18 +69,13 @@ class _job_state_monitor(threading.Thread):
                     # terminal state, so we can skip the ones that are 
                     # either done, failed or canceled
                     if  job_info['state'] not in [saga.job.DONE, saga.job.FAILED, saga.job.CANCELED] :
-                        
-                        # Store the current state since the current state 
-                        # variable is updated when _job_get_info is called
-                        pre_update_state = job_info['state']
 
                         new_job_info = self.js._job_get_info(job_id, reconnect=False)
-                        self.logger.info ("Job monitoring thread updating Job "
-                                          "%s (old state: %s, new state: %s)" % 
-                                          (job_id, pre_update_state, new_job_info['state']))
+                        self.logger.info ("Job monitoring thread updating Job %s (state: %s)" \
+                                       % (job_id, new_job_info['state']))
 
                         # fire job state callback if 'state' has changed
-                        if  new_job_info['state'] != pre_update_state:
+                        if  new_job_info['state'] != job_info['state']:
                             job_obj = job_info['obj']
                             job_obj._attributes_i_set('state', new_job_info['state'], job_obj._UP, True)
 

--- a/src/saga/adaptors/pbs/pbsjob.py
+++ b/src/saga/adaptors/pbs/pbsjob.py
@@ -69,13 +69,18 @@ class _job_state_monitor(threading.Thread):
                     # terminal state, so we can skip the ones that are 
                     # either done, failed or canceled
                     if  job_info['state'] not in [saga.job.DONE, saga.job.FAILED, saga.job.CANCELED] :
+                        
+                        # Store the current state since the current state 
+                        # variable is updated when _job_get_info is called
+                        pre_update_state = job_info['state']
 
                         new_job_info = self.js._job_get_info(job_id, reconnect=False)
-                        self.logger.info ("Job monitoring thread updating Job %s (state: %s)" \
-                                       % (job_id, new_job_info['state']))
+                        self.logger.info ("Job monitoring thread updating Job "
+                                          "%s (old state: %s, new state: %s)" % 
+                                          (job_id, pre_update_state, new_job_info['state']))
 
                         # fire job state callback if 'state' has changed
-                        if  new_job_info['state'] != job_info['state']:
+                        if  new_job_info['state'] != pre_update_state:
                             job_obj = job_info['obj']
                             job_obj._attributes_i_set('state', new_job_info['state'], job_obj._UP, True)
 

--- a/src/saga/adaptors/pbspro/pbsprojob.py
+++ b/src/saga/adaptors/pbspro/pbsprojob.py
@@ -69,12 +69,17 @@ class _job_state_monitor(threading.Thread):
                     # either done, failed or canceled
                     if  job_info['state'] not in [saga.job.DONE, saga.job.FAILED, saga.job.CANCELED] :
 
+                        # Store the current state since the current state 
+                        # variable is updated when _job_get_info is called
+                        pre_update_state = job_info['state']
+
                         new_job_info = self.js._job_get_info(job_id, reconnect=False)
-                        self.logger.info ("Job monitoring thread updating Job %s (state: %s)" \
-                                       % (job_id, new_job_info['state']))
+                        self.logger.info ("Job monitoring thread updating Job "
+                                          "%s (old state: %s, new state: %s)" % 
+                                          (job_id, pre_update_state, new_job_info['state']))
 
                         # fire job state callback if 'state' has changed
-                        if  new_job_info['state'] != job_info['state']:
+                        if  new_job_info['state'] != pre_update_state:
                             job_obj = job_info['obj']
                             job_obj._attributes_i_set('state', new_job_info['state'], job_obj._UP, True)
 

--- a/src/saga/adaptors/torque/torquejob.py
+++ b/src/saga/adaptors/torque/torquejob.py
@@ -69,13 +69,18 @@ class _job_state_monitor(threading.Thread):
                     # terminal state, so we can skip the ones that are 
                     # either done, failed or canceled
                     if  job_info['state'] not in [saga.job.DONE, saga.job.FAILED, saga.job.CANCELED] :
+                        
+                        # Store the current state since the current state 
+                        # variable is updated when _job_get_info is called
+                        pre_update_state = job_info['state']
 
                         new_job_info = self.js._job_get_info(job_id, reconnect=False)
-                        self.logger.info ("Job monitoring thread updating Job %s (state: %s)" \
-                                       % (job_id, new_job_info['state']))
+                        self.logger.info ("Job monitoring thread updating Job "
+                                          "%s (old state: %s, new state: %s)" % 
+                                          (job_id, pre_update_state, new_job_info['state']))
 
                         # fire job state callback if 'state' has changed
-                        if  new_job_info['state'] != job_info['state']:
+                        if  new_job_info['state'] != pre_update_state:
                             job_obj = job_info['obj']
                             job_obj._attributes_i_set('state', new_job_info['state'], job_obj._UP, True)
 


### PR DESCRIPTION
Modified the PBS, PBSPro and Torque adaptors to resolve issue #500 that was preventing state callbacks from being correctly made when the job state monitor thread detects a change in state.