### PR TITLE
fix regression in job cancellation

### DIFF
--- a/src/saga/adaptors/shell/shell_wrapper.sh
+++ b/src/saga/adaptors/shell/shell_wrapper.sh
@@ -280,6 +280,7 @@ create_monitor () {
   \\chmod 0700               \$DIR/cmd
 
   (
+    trap - HUP
     export SAGA_PWD="\$DIR"
     export SAGA_UPID="\$UPID"
     \\printf  "`\date` : RUNNING \\n" >> "\$DIR/log"


### PR DESCRIPTION
We need to re-instiate the default HUP handler to make sure that the whole process group goes away.