### PR TITLE
Added new PBS versions to pbsnodes CPU count check.

### DIFF
--- a/src/saga/adaptors/pbs/pbsjob.py
+++ b/src/saga/adaptors/pbs/pbsjob.py
@@ -614,7 +614,7 @@ class PBSJobService (saga.adaptors.cpi.job.Service):
 
         # TODO: this is quite a hack. however, it *seems* to work quite
         #       well in practice.
-        if 'PBSPro_12' in self._commands['qstat']['version']:
+        if any(ver in self._commands['qstat']['version'] for ver in ('PBSPro_13', 'PBSPro_12', 'PBSPro_11.3')):
             ret, out, _ = self.shell.run_sync('unset GREP_OPTIONS; %s -a | grep -E "resources_available.ncpus"' % \
                                                self._commands['pbsnodes']['path'])
         else:

--- a/src/saga/adaptors/pbspro/pbsprojob.py
+++ b/src/saga/adaptors/pbspro/pbsprojob.py
@@ -615,7 +615,7 @@ class PBSProJobService (saga.adaptors.cpi.job.Service):
 
         # TODO: this is quite a hack. however, it *seems* to work quite
         #       well in practice.
-        if 'PBSPro_12' in self._commands['qstat']['version']:
+        if any(ver in self._commands['qstat']['version'] for ver in ('PBSPro_13', 'PBSPro_12', 'PBSPro_11.3')):
             ret, out, _ = self.shell.run_sync('unset GREP_OPTIONS; %s -a | grep -E "resources_available.ncpus"' % \
                                                self._commands['pbsnodes']['path'])
         else:


### PR DESCRIPTION
This one keeps catching me out! I've been testing some code with PBS 11 and 13 platforms and after the check for PBS12 fails in [pbsjob.py:617](https://github.com/radical-cybertools/saga-python/blob/cd1fbfd942adbff2172ceb250771d9525ecde585/src/saga/adaptors/pbs/pbsjob.py#L617), the alternative attempt to grep the output of `pbsnodes -a` (`grep -E "(np|pcpu)[[:blank:]]*=" '`) then also fails resulting in the job failing with `Error running pbsnodes`.

It seems that PBS 11 and 13 require the same check as used for PBS 12 so I've added these two versions into this code path. Have updated both `pbsjob.py` and `pbsprojob.py` to ensure that this doesn't catch out anyone still using the old pbs adaptor. 