### PR TITLE
Removed duplicate get_name function in job class

### DIFF
--- a/src/saga/job/job.py
+++ b/src/saga/job/job.py
@@ -164,13 +164,12 @@ class Job (sb.Base, st.Task, sasync.Async) :
     @rus.returns ((rus.nothing, basestring, st.Task))
     def get_name (self, ttype=None) :
         """
-        get_id()
+        get_name()
 
         Return the job name. 
         """
         name = self._adaptor.get_name(ttype=ttype)
         return name
-
 
     # --------------------------------------------------------------------------
     #
@@ -634,19 +633,6 @@ class Job (sb.Base, st.Task, sasync.Async) :
         get_result()
         """
         return self._adaptor.get_result (ttype=ttype)
-
-
-    # --------------------------------------------------------------------------
-    #
-    @rus.takes     ('Job',
-                    rus.optional (rus.one_of (SYNC, ASYNC, TASK)))
-    @rus.returns   ((basestring, st.Task))
-    def get_name   (self, ttype=None) :
-        """
-        get_name()
-        """
-        return self._adaptor.get_name (ttype=ttype)
-
 
     # --------------------------------------------------------------------------
     #


### PR DESCRIPTION
Removed duplicate `get_name` function in the `Job` class in `src/saga/job/job.py`.