### PR TITLE
Relative to discussion about #578

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,3 @@ docs/source/adaptors/saga.adaptor*
 
 # PyCharm
 .idea
-/.pycharmrc
-Supprimerait .pycharmrc

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ docs/source/adaptors/saga.adaptor*
 
 # PyCharm
 .idea
+/.pycharmrc
+Supprimerait .pycharmrc

--- a/src/saga/adaptors/context/myproxy.py
+++ b/src/saga/adaptors/context/myproxy.py
@@ -21,7 +21,18 @@ ASYNC_CALL = saga.adaptors.cpi.decorators.ASYNC_CALL
 #
 _ADAPTOR_NAME          = 'saga.adaptor.myproxy'
 _ADAPTOR_SCHEMAS       = ['MyProxy']
-_ADAPTOR_OPTIONS       = []
+_ADAPTOR_OPTIONS       = [
+    {
+    'category'         : 'saga.adaptor.myproxy',
+    'name'             : 'base_workdir',
+    'type'             : str,
+    'default'          : "$HOME/.saga/adaptors/proxies/",
+    'documentation'    : '''The adaptor stores job state information on the
+                          filesystem on the target resource.  This parameter
+                          specified what location should be used.''',
+    'env_variable'     : None
+    }
+]
 
 _ADAPTOR_CAPABILITIES  = {
     'attributes'       : [saga.context.TYPE,
@@ -68,6 +79,7 @@ class Adaptor (saga.adaptors.base.Base):
 
         # there are no default myproxy contexts
         self._default_contexts = []
+        self.base_work_dir = self.opts['base_work_dir'].get_value()
 
 
     def sanity_check (self) :
@@ -90,6 +102,7 @@ class ContextMyProxy (saga.adaptors.cpi.context.Context) :
 
         _cpi_base = super  (ContextMyProxy, self)
         _cpi_base.__init__ (api, adaptor)
+        self.base_work_dir = adaptor.base_work_dir
 
 
     @SYNC_CALL
@@ -135,7 +148,7 @@ class ContextMyProxy (saga.adaptors.cpi.context.Context) :
             cmd += " --proxy_lifetime %s"  %  api.life_time
 
         # store the proxy in a private location
-        proxy_store    = "%s/.saga/proxies/"   %  os.environ['HOME']
+        proxy_store    = "%s"   %  self.base_work_dir
         proxy_location = "%s/myproxy_%d.x509"  %  (proxy_store, id(self))
 
         if not os.path.exists (proxy_store) :

--- a/src/saga/adaptors/context/myproxy.py
+++ b/src/saga/adaptors/context/myproxy.py
@@ -27,7 +27,7 @@ _ADAPTOR_OPTIONS       = [
     'name'             : 'base_workdir',
     'type'             : str,
     'default'          : "$HOME/.saga/adaptors/proxies/",
-    'documentation'    : '''The adaptor stores job state information on the
+    'documentation'    : '''The adaptor stores proxies information on the
                           filesystem on the target resource.  This parameter
                           specified what location should be used.''',
     'env_variable'     : None
@@ -79,7 +79,7 @@ class Adaptor (saga.adaptors.base.Base):
 
         # there are no default myproxy contexts
         self._default_contexts = []
-        self.base_work_dir = self.opts['base_work_dir'].get_value()
+        self.base_workdir = self.opts['base_workdir'].get_value()
 
 
     def sanity_check (self) :
@@ -102,7 +102,7 @@ class ContextMyProxy (saga.adaptors.cpi.context.Context) :
 
         _cpi_base = super  (ContextMyProxy, self)
         _cpi_base.__init__ (api, adaptor)
-        self.base_work_dir = adaptor.base_work_dir
+        self.base_workdir = adaptor.base_workdir
 
 
     @SYNC_CALL
@@ -148,7 +148,7 @@ class ContextMyProxy (saga.adaptors.cpi.context.Context) :
             cmd += " --proxy_lifetime %s"  %  api.life_time
 
         # store the proxy in a private location
-        proxy_store    = "%s"   %  self.base_work_dir
+        proxy_store    = "%s" % self.base_workdir
         proxy_location = "%s/myproxy_%d.x509"  %  (proxy_store, id(self))
 
         if not os.path.exists (proxy_store) :

--- a/src/saga/adaptors/sge/sgejob.py
+++ b/src/saga/adaptors/sge/sgejob.py
@@ -139,7 +139,7 @@ _ADAPTOR_OPTIONS       = [
     'category'         : 'saga.adaptor.sgejob',
     'name'             : 'base_workdir',
     'type'             : str,
-    'default'          : "$HOME/.saga/adaptors/shell_job/",
+    'default'          : "$HOME/.saga/adaptors/sge_job/",
     'documentation'    : '''The adaptor stores job state information on the
                           filesystem on the target resource.  This parameter
                           specified what location should be used.''',
@@ -234,7 +234,7 @@ class Adaptor (saga.adaptors.base.Base):
 
         self.purge_on_start = self.opts['purge_on_start'].get_value()
         self.purge_older_than = self.opts['purge_older_than'].get_value()
-        self.base_work_dir = self.opts['base_work_dir'].get_value()
+        self.base_work_dir = self.opts['base_workdir'].get_value()
 
     # ----------------------------------------------------------------
     #

--- a/src/saga/adaptors/sge/sgejob.py
+++ b/src/saga/adaptors/sge/sgejob.py
@@ -234,7 +234,7 @@ class Adaptor (saga.adaptors.base.Base):
 
         self.purge_on_start = self.opts['purge_on_start'].get_value()
         self.purge_older_than = self.opts['purge_older_than'].get_value()
-        self.base_work_dir = self.opts['base_workdir'].get_value()
+        self.base_workdir = self.opts['base_workdir'].get_value()
 
     # ----------------------------------------------------------------
     #
@@ -292,7 +292,7 @@ class SGEJobService (saga.adaptors.cpi.job.Service):
         self.shell   = None
         self.mandatory_memreqs = list()
         self.accounting = False
-        self.temp_path = self._adaptor.base_work_dir
+        self.temp_path = self._adaptor.base_workdir
 
 
         rm_scheme = rm_url.scheme

--- a/src/saga/adaptors/sge/sgejob.py
+++ b/src/saga/adaptors/sge/sgejob.py
@@ -135,6 +135,16 @@ _ADAPTOR_OPTIONS       = [
                             of days to consider a temporary file older enough to be deleted.''',
     'env_variable'     : None
     },
+    {
+    'category'         : 'saga.adaptor.sgejob',
+    'name'             : 'base_workdir',
+    'type'             : str,
+    'default'          : "$HOME/.saga/adaptors/shell_job/",
+    'documentation'    : '''The adaptor stores job state information on the
+                          filesystem on the target resource.  This parameter
+                          specified what location should be used.''',
+    'env_variable'     : None
+    }
 ]
 # --------------------------------------------------------------------
 # the adaptor capabilities & supported attributes
@@ -224,6 +234,7 @@ class Adaptor (saga.adaptors.base.Base):
 
         self.purge_on_start = self.opts['purge_on_start'].get_value()
         self.purge_older_than = self.opts['purge_older_than'].get_value()
+        self.base_work_dir = self.opts['base_work_dir'].get_value()
 
     # ----------------------------------------------------------------
     #
@@ -281,7 +292,7 @@ class SGEJobService (saga.adaptors.cpi.job.Service):
         self.shell   = None
         self.mandatory_memreqs = list()
         self.accounting = False
-        self.temp_path = "$HOME/.saga/adaptors/sge_job"
+        self.temp_path = self._adaptor.base_work_dir
 
 
         rm_scheme = rm_url.scheme
@@ -428,7 +439,7 @@ class SGEJobService (saga.adaptors.cpi.job.Service):
 
         # purge temporary files
         if self._adaptor.purge_on_start:
-            cmd = "find $HOME/.saga/adaptors/sge_job" \
+            cmd = "find " + self.temp_path + \
                   " -type f -mtime +%d -print -delete | wc -l" % self._adaptor.purge_older_than
             ret, out, _ = self.shell.run_sync(cmd)
             if ret == 0 and out != "0":


### PR DESCRIPTION
This is my little contribution about discussion in https://github.com/radical-cybertools/saga-python/issues/578.

I was thinking about setting up a hierarchy in configurations in order to get this "'baseworking dir" available once for all adaptors (and be able to potentially override for a specific one).

By the way I noticed an error in your doc : the configuration file used is not named .saga.conf, but .saga.cfg (and this file does not allow indents)
