### PR TITLE
Fix for issue #586, removing HOME env var from shell wrapper script file path

### DIFF
--- a/src/saga/adaptors/shell/shell_job.py
+++ b/src/saga/adaptors/shell/shell_job.py
@@ -575,6 +575,13 @@ class ShellJobService (saga.adaptors.cpi.job.Service) :
               # src = shell_wrapper._WRAPPER_SCRIPT % ({ 'PURGE_ON_START' : str(self._adaptor.purge_on_start) })
                 src = shell_wrapper._WRAPPER_SCRIPT
                 src = src.replace('%(PURGE_ON_START)s', str(self._adaptor.purge_on_start))
+                
+                # If the target directory begins with $HOME or ${HOME} then we
+                # need to remove this since scp won't expand the variable and
+                # the copy will end up attempting to copy the file to 
+                # /<path_to_home_dir>/$HOME/.....
+                if tgt.startswith("$HOME") or tgt.startswith("${HOME}"):
+                    tgt = tgt[tgt.find('/')+1:]
                 self.shell.write_to_remote (src, tgt)
 
         # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #586 by checking the start of the target file path when placing the shell job adapter `wrapper.sh` script into `~/.saga/...`. If the target path starts with `$HOME/` or `${HOME}/` then this is removed because sftp accepts a relative path as being relative to the authenticating user's home directory.