### PR TITLE
Fixed processes per host (#ranks/node) in SLURM-settings.

### DIFF
--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -459,11 +459,11 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
             mpi_cmd = ''
             slurm_script += "#SBATCH --ntasks=%s\n" % (number_of_processes)
 
-            if total_cpu_count and number_of_processes:
+            if not processes_per_host:
                 slurm_script += "#SBATCH --cpus-per-task=%s\n" \
                               % (int(total_cpu_count / number_of_processes))
 
-            if processes_per_host:
+            else:
                 slurm_script += "#SBATCH --ntasks-per-node=%s\n" % processes_per_host
 
         if 'bridges' in self.rm.host.lower():


### PR DESCRIPTION
Old:
```
if total_cpu_count and number_of_processes:
```
is always true (set before). 

```
int(total_cpu_count / number_of_processes)
```
gives `0` if `total_cpu_count` is not set manually (Slurm error).

----

New:

Only sets `--cpus-per-task` if `processes_per_host` is not set.
Having both, `--cpus-per-task` and `--ntasks-per-node` doesn't make much sense anyways.
Also `--cpus-per-task` is quite annoying since it requires setting it to the number of hyperthreads for a full node.