### PR TITLE
fix task container get_state reval

### DIFF
--- a/src/saga/task.py
+++ b/src/saga/task.py
@@ -621,7 +621,7 @@ class Container (sbase.SimpleBase, satt.Attributes) :
 
         # We still need to get the states from all futures.
         # FIXME: order
-        states  = []
+        states = list()
 
         for future in futures :
             future.join ()
@@ -633,7 +633,7 @@ class Container (sbase.SimpleBase, satt.Attributes) :
             res = future.result
 
             if res != None :
-                states += res
+                states.append(res)
 
         return states
 


### PR DESCRIPTION
I am not sure how that went undetected for so long, but here we are...