### PR TITLE
accept SID settings from upper layers (RP)

### DIFF
--- a/src/saga/base.py
+++ b/src/saga/base.py
@@ -28,13 +28,16 @@ class SimpleBase (object) :
     #
     @rus.takes   ('SimpleBase')
     @rus.returns (rus.nothing)
-    def __init__  (self) :
+    def __init__  (self, uid=None):
 
         if  not hasattr (self, '_apitype') :
             self._apitype = self._get_apitype ()
 
         self._logger = ru.get_logger  ('radical.saga')
-        self._id     = ru.generate_id (self._get_apitype (), mode=ru.ID_SIMPLE)
+        if uid:
+            self._id = uid
+        else:
+            self._id = ru.generate_id (self._get_apitype (), mode=ru.ID_SIMPLE)
 
       # self._logger.debug ("[saga.Base] %s.__init__()" % self._apitype)
 

--- a/src/saga/session.py
+++ b/src/saga/session.py
@@ -166,14 +166,14 @@ class Session (saga.base.SimpleBase) :
     @rus.takes   ('Session', 
                   rus.optional(bool))
     @rus.returns (rus.nothing)
-    def __init__ (self, default=True):
+    def __init__ (self, default=True, uid=None):
         """
         default: bool
         ret:     None
         """
 
         simple_base = super  (Session, self)
-        simple_base.__init__ ()
+        simple_base.__init__ (uid=uid)
 
         self._logger = ru.get_logger ('radical.saga')
 


### PR DESCRIPTION
Matteo - I forgot to assign this one to you, too -- its the counterpart to radical-cybertools/radical.pilot/pull/1539 on the SAGA layer, which now accepts the uid to be specified on session creation, and only throws the dices for a new ID if none is given.

This needs to be merged before radical-cybertools/radical.pilot/pull/1539 - but in its self its backward compatible (the uid parameter is optional).  It is in sync with all other Session constructors in the RCT stack.