### PR TITLE
Fix/issue 686

### DIFF
--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -483,6 +483,12 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
                 number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))
                 slurm_script += "#SBATCH -N %d --ntasks=%s\n" % (number_of_nodes, 
                                                                  number_of_processes)
+            elif self._version == '18.08.0':
+        
+                assert(self._ppn), 'need unique number of cores per node'
+                number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))
+                slurm_script += "#SBATCH -N %d --ntasks=%s\n" % (number_of_nodes, 
+                                                                 number_of_processes)
             else:
                 slurm_script += "#SBATCH --ntasks=%s\n" % (number_of_processes)
 

--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -477,13 +477,7 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
             # we start N independent processes
             mpi_cmd = ''
 
-            if self._version == '17.11.5':
-        
-                assert(self._ppn), 'need unique number of cores per node'
-                number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))
-                slurm_script += "#SBATCH -N %d --ntasks=%s\n" % (number_of_nodes, 
-                                                                 number_of_processes)
-            elif self._version == '18.08.0':
+            if self._version in ['17.11.5', '18.08.0']:
         
                 assert(self._ppn), 'need unique number of cores per node'
                 number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))

--- a/src/saga/adaptors/slurm/slurm_job.py
+++ b/src/saga/adaptors/slurm/slurm_job.py
@@ -385,7 +385,7 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
                     '| xargs echo'
         _, out, _ = self.shell.run_sync(ppn_cmd)
         ppn_vals  = [o.strip() for o in out.split() if o.strip()]
-        if len(ppn_vals) == 1: self._ppn = int(ppn_vals[0])
+        if len(ppn_vals) >= 1: self._ppn = int(ppn_vals[0])
         else                 : self._ppn = None
 
         self._logger.info(" === ppn: %s", self._ppn)


### PR DESCRIPTION
I would like to note that SLURM version on Stampede2 is `18.08.0` and also it return the following as `ppn_vals`:
```
2018-09-24 15:32:36,175: radical.saga.cpi    : MainProcess                     : MainThread     : INFO    :  === ppn_vals: ['272', '96']
```
As a result the check has changed from equal to 1 to larger of equal to 1